### PR TITLE
Fix service connection name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This example also requires an Azure Machine Learning service workspace. For more
 
 You can clone this repo and use it with Azure Pipelines. Before creating the pipeline you must do the following:
 
-1. Create a [service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops) named `azmldemows`. This connection must reference your Azure subscription and the Azure resource group that contains your Azure Machine Learning service workspace.
+1. Create a [service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops) named `build-demo`. This connection must reference your Azure subscription and the Azure resource group that contains your Azure Machine Learning service workspace.
 1. Modify the `azure-pipelines.yml` and change `myresourcegroup` to the Azure resource group that contains your workspace. You must also change the `myworkspace` entry to the name of your Azure Machine Learning service workspace.
 1. When creating the pipeline for the project, you can point it to the `azure-pipelines.yml` file. This defines an example pipeline.
 


### PR DESCRIPTION
Fix service connection name in README to match the contents of `azure-pipelines.yml`.